### PR TITLE
Switching to request objects. #9

### DIFF
--- a/server/lib/db.ts
+++ b/server/lib/db.ts
@@ -1,6 +1,7 @@
 // Setup the lowdb database
 import low from "lowdb";
 import FileSync from "lowdb/adapters/FileSync";
+import { PractitionerSchema } from "./practitioner-schema";
 
 const adapter = new FileSync(".data/db.json");
 
@@ -62,8 +63,11 @@ export default () => {
               // We also dont need the "Rank Code," whatever that is.
               array.splice(3, 1);
 
-              return array;
+              return new PractitionerSchema(array);
             });
+
+          //drop the headers
+          data.shift();
 
           db.set("data", data).write();
 
@@ -79,8 +83,8 @@ export default () => {
           db.set(
             "search_data",
             data.slice(1).map(counselor => ({
-              id: counselor[0],
-              text: counselor.join(" "),
+              id: counselor.licId,
+              text: JSON.stringify(counselor),
               node: counselor
             }))
           ).write();

--- a/server/lib/practitioner-schema.ts
+++ b/server/lib/practitioner-schema.ts
@@ -1,0 +1,75 @@
+export class PractitionerSchema {
+    licId: string;
+    expDate: string;
+    orgDate: string;
+    licenseNum: string;
+    statusDate: Date;
+    boardAction: string;
+    licenseStatusDesc: string;
+    lastName: string;
+    firstName: string;
+    middleName: string;
+    nameSuffix: string;
+    businessName: string;
+    licenseActiveStatus: string;
+    county: string;
+    countyDesc: string;
+
+    mailingLine1: string;
+    mailingLine2: string;
+    mailingCity: string;
+    mailingState: string;
+    mailingZIP: string;
+
+    practiceLine1: string;
+    practiceLine2: string;
+    practiceCity: string;
+    practiceState: string;
+    practiceZIP: string;
+
+    phoneNum: string;
+    phoneExt: string;
+    area: string;
+
+    email: string;
+    modCodes: string;
+    prescriptionIndicator: string;
+    dispensingIndicator: string;
+
+    constructor(raw: any) {
+        if (raw) {
+            this.licId = raw[0];
+            this.expDate = raw[1];
+            this.orgDate = raw[2];
+            this.licenseNum = raw[3];
+            this.statusDate = raw[4];
+            this.boardAction = raw[5];
+            this.licenseStatusDesc = raw[6];
+            this.lastName = raw[7];
+            this.firstName = raw[8];
+            this.middleName = raw[9];
+            this.nameSuffix = raw[10];
+            this.businessName = raw[11];
+            this.licenseActiveStatus = raw[12];
+            this.county = raw[13];
+            this.countyDesc = raw[14];
+            this.mailingLine1 = raw[15];
+            this.mailingLine2 = raw[16];
+            this.mailingCity = raw[17];
+            this.mailingState = raw[18];
+            this.mailingZIP = raw[19];
+            this.area = raw[20];
+            this.phoneNum = raw[21];
+            this.phoneExt = raw[22];
+            this.practiceLine1 = raw[23];
+            this.practiceLine2 = raw[24];
+            this.practiceCity = raw[25];
+            this.practiceState = raw[26];
+            this.practiceZIP = raw[27];
+            this.email = raw[28];
+            this.modCodes = raw[29];
+            this.prescriptionIndicator = raw[30];
+            this.dispensingIndicator = raw[31];
+        }
+    }
+}

--- a/src/components/practitioner.ts
+++ b/src/components/practitioner.ts
@@ -1,98 +1,62 @@
+import { PractitionerSchema } from "../../server/lib/practitioner-schema";
 
-export class Practitioner {
-    licId: string;
-    expDate: string;
-    orgDate: string;
-    licenseNum: string;
-    statusDate: Date;
-    boardAction: string;
-    licenseStatusDesc: string;
-    lastName: string;
-    firstName: string;
-    middleName: string;
-    nameSuffix: string;
-    businessName: string;
-    licenseActiveStatus: string;
-    county: string;
-    countyDesc: string;
-
+export class Practitioner extends PractitionerSchema {
     phone: Phone;
-
     mailingAddress: Address;
     practiceAddress: Address;
 
-    email: string;
-    modCodes: string;
-    prescriptionIndicator: string;
-    dispensingIndicator: string;
-
     public static LABEL_INFO = {
-        licId: { heading: "Lic. ID", width: 80, queryString: "lic_id" },
-        expDate: { heading: "Expiry Date", width: 120, queryString: "Expire-Date" },
-        orgDate: { heading: "Original Date", width: 120, queryString: "Original-Date" },
-        licenseNum: { heading: "Lic. #", width: 80, queryString: "License-Number" },
-        statusDate: { heading: "Effective Date", width: 120, queryString: "Status-Effective-Date" },
-        boardAction: { heading: "Board Action?", width: 150, queryString: "Board-Action-Indicator" },
-        licenseStatusDesc: { heading: "License Status", width: 140, queryString: "License-Status-Description" },
-        lastName: { heading: "Last", width: 140, queryString: "Last-Name" },
-        firstName: { heading: "First", width: 140, queryString: "First-Nam" },
-        middleName: { heading: "Middle", width: 80, queryString: "Middle-Name" },
-        nameSuffix: { heading: "Suffix", width: 60, queryString: "Name-Suffix" },
-        businessName: { heading: "Business", width: 80, queryString: "Business-Name" },
-        licenseActiveStatus: { heading: "Active?", width: 80, queryString: "License-Active-Status-Description" },
-        county: { heading: "County Num", width: 40, queryString: "County" },
-        countyDesc: { heading: "County Name", width: 140, queryString: "County-Description" },
-        phone: { heading: "Phone Num", width: 300, queryString: "" },
-        mailingAddress: { heading: "Mailing Address", width: 500, queryString: "" },
-        practiceAddress: { heading: "Practice Address", width: 500, queryString: "" },
-        email: { heading: "Email", width: 240, queryString: "Email" },
-        modCodes: { heading: "Mod Codes", width: 200, queryString: "Mod-Cdes" },
-        prescriptionIndicator: { heading: "Prescribe?", width: 110, queryString: "Prescribe-Ind" },
-        dispensingIndicator: { heading: "Dispensing?", width: 120, queryString: "Dispensing-Ind" }
+        licId: { heading: "Lic. ID", width: 80 },
+        expDate: { heading: "Expiry Date", width: 120 },
+        orgDate: { heading: "Original Date", width: 120 },
+        licenseNum: { heading: "Lic. #", width: 80 },
+        statusDate: { heading: "Effective Date", width: 120 },
+        boardAction: { heading: "Board Action?", width: 150 },
+        licenseStatusDesc: { heading: "License Status", width: 140 },
+        lastName: { heading: "Last", width: 140 },
+        firstName: { heading: "First", width: 140 },
+        middleName: { heading: "Middle", width: 80 },
+        nameSuffix: { heading: "Suffix", width: 60 },
+        businessName: { heading: "Business", width: 80 },
+        licenseActiveStatus: { heading: "Active?", width: 80 },
+        county: { heading: "County Num", width: 40 },
+        countyDesc: { heading: "County Name", width: 140 },
+        phone: { heading: "Phone Num", width: 300 },
+        mailingAddress: { heading: "Mailing Address", width: 500 },
+        practiceAddress: { heading: "Practice Address", width: 500 },
+        email: { heading: "Email", width: 240 },
+        modCodes: { heading: "Mod Codes", width: 200 },
+        prescriptionIndicator: { heading: "Prescribe?", width: 110 },
+        dispensingIndicator: { heading: "Dispensing?", width: 120 }
     };
 
-    constructor(raw: any) {
-        this.licId = raw[0];
-        this.expDate = raw[1];
-        this.orgDate = raw[2];
-        this.licenseNum = raw[3];
-        this.statusDate = raw[4];
-        this.boardAction = raw[5];
-        this.licenseStatusDesc = raw[6];
-        this.lastName = raw[7];
-        this.firstName = raw[8];
-        this.middleName = raw[9];
-        this.nameSuffix = raw[10];
-        this.businessName = raw[11];
-        this.licenseActiveStatus = raw[12];
-        this.county = raw[13];
-        this.countyDesc = raw[14];
+    constructor(src: PractitionerSchema) {
+        super(null);
+
+        Object.keys(src).forEach(key => this[key] = src[key]);
+
         this.mailingAddress = {
             discriminator: "isAddress",
-            line1: raw[15],
-            line2: raw[16],
-            city: raw[17],
-            state: raw[18],
-            ZIP: raw[19]
+            line1: this.mailingLine1,
+            line2: this.mailingLine2,
+            city: this.mailingCity,
+            state: this.mailingState,
+            ZIP: this.mailingZIP
         };
         this.phone = {
             discriminator: "isPhone",
-            area: raw[20],
-            phoneNum: raw[21],
-            phoneExt: raw[22]
+            area: this.area,
+            phoneNum: this.phoneNum,
+            phoneExt: this.phoneExt
         };
         this.practiceAddress = {
             discriminator: "isAddress",
-            line1: raw[23],
-            line2: raw[24],
-            city: raw[25],
-            state: raw[26],
-            ZIP: raw[27]
+            line1: this.practiceLine1,
+            line2: this.practiceLine2,
+            city: this.practiceCity,
+            state: this.practiceState,
+            ZIP: this.practiceZIP
         };
-        this.email = raw[28];
-        this.modCodes = raw[29];
-        this.prescriptionIndicator = raw[30];
-        this.dispensingIndicator = raw[31];
     }
 
     public static getTotalWidth(): number {


### PR DESCRIPTION
Created `PractitionerSchema` object that acts as both database and response/request schema. The `Practitioner` now extends the above to insure that they are in sync with one another.

Things to consider:
* Logic to handle `practiceAddress`, `phone` and `mailingAddress` objects on the server side.

Resolves #9 